### PR TITLE
Fix cred issue

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -2,7 +2,10 @@ import admin from 'firebase-admin';
 
 import * as functions from 'firebase-functions';
 
-admin.initializeApp(functions.config().firebase);
+const firebaseAdminConfig = {
+  credential: admin.credential.applicationDefault()
+};
+admin.initializeApp(firebaseAdminConfig);
 
 import contributors from './api/contributors';
 import lists from './api/lists';

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,8 @@
     "lint:fix":
       "tslint --fix -c ./tslint.json './*/*.ts' './*.ts' -e './node_modules'",
     "serve": "(tsc || true) && firebase serve",
+    "dev":
+      "(tsc || true) && GOOGLE_APPLICATION_CREDENTIALS='./secrets/google-key.json' firebase serve",
     "start": "(tsc || true) && npm run shell",
     "deploy": "(tsc || true) && firebase deploy --only functions",
     "logs": "(tsc || true) && firebase functions:log",


### PR DESCRIPTION
based on: https://firebase.google.com/docs/admin/setup?authuser=0

this issue only appeared in development
in production, the credential was derived from the production environment itself
it was probably setting the GOOGLE_APPLICATION_CREDENTIALS in the background

for local dev this threw an error as described in #149 

so from now, to run dev server, run `npm run dev`